### PR TITLE
メッセージ送信の非同期化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,69 @@
+$(document).on('turbolinks:load', function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+       `<div class="message">
+          <div class="upper-message">
+            <div class="upper-message__user-name">
+              ${message.user_name}
+            </div>
+            <div class="upper-message__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="lower-message">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+          <img src=${message.image} >
+        </div>`
+      return html;
+    } else {
+      var html =
+       `<div class="message">
+          <div class="upper-message">
+            <div class="upper-message__user-name">
+              ${message.user_name}
+            </div>
+            <div class="upper-message__date">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="lower-message">
+            <p class="lower-message__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
+  $('#new_message').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      $('form')[0].reset();
+    })
+
+    .fail(function(message) {
+      alert("メッセージ送信に失敗しました");
+    });
+
+    .always(function(message){
+      $('.submit-btn').prop('disabled', false);
+    })
+  })
+});

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -90,6 +90,7 @@
         height: 50px;
         position: relative;
         border-style: none;
+        position: relative;
         
         .image-label {
           position: absolute;
@@ -102,6 +103,7 @@
         }
       }
       .submit-btn{
+        width: 100px;
         height: 50px;
         margin-left: 15px;
         padding: 0px 30px;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -6,8 +6,6 @@
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render "layouts/notifications"
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{content: "text/html ; charset=UTF-8", "http-equiv": "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
     = render "layouts/notifications"
     = yield

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -16,7 +16,7 @@
   .main__form
     .input-box
       = form_for [@group, @message] do |f|
-        = f.text_field :content, class: 'input-box', placeholder: 'type a message'
+        = f.text_field :content, class: 'input-text', placeholder: 'type a message'
         .input__text
           = f.label :image, class: 'image-label'do
             = icon('fa', 'image', class: 'icon')

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,5 +1,4 @@
 .message
-  -# - @messages.each do |message|
   .user
     .user__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,8 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
+    
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# what
フォームが送信されたら、イベントが発火するようにする
イベントが発火したときにAjaxを使用して、messages#createが動くようにする
 messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
 jbuilderを使用して、作成したメッセージをJSON形式で返す
 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
 作成したHTMLをメッセージ画面の一番下に追加する
メッセージを送信したとき、メッセージ画面を最下部にスクロールする
 連続で送信ボタンを押せるようにする
 非同期に失敗した場合の処理も準備する

# why
ページを遷移することなく、ページの一部だけを更新し、同時にサーバと通信を行うことができるようにするため

# gif
 [https://gyazo.com/9f28c1fb254d84473b079ba6d3b48b68](url)